### PR TITLE
Check if FTP connection succeeded

### DIFF
--- a/Ftp.php
+++ b/Ftp.php
@@ -74,6 +74,9 @@ class Ftp
             } catch (\ErrorException $e) {
                 throw new FtpException($e->getMessage());
             }
+            if (!is_resource($this->resource)) {
+                throw new FtpException("An error occured while trying to connect to FTP server.");
+            }
             $result = null;
 
         } elseif (!is_resource($this->resource)) {


### PR DESCRIPTION
ftp_connect can trigger a warning when not successful.
In that case no ErrorException is thrown, and it was impossible to know wether the connection succeeded.
Now Throws a FtpException if no resource was returned by ftp_connect.