### PR TITLE
Always chdir to current when isDir is called

### DIFF
--- a/Ftp.php
+++ b/Ftp.php
@@ -115,8 +115,9 @@ class Ftp
     	try {
     		$this->chdir($dir);
     	} catch (FtpException $e) {
+    	} finally {
     	    $this->chdir($current);
-    	}
+        }
     	return empty($e);
     }
     


### PR DESCRIPTION
Just chdir in any case. We only want to check if directory exists. If it exists chdir on line 116 change current working directory and following action are in this sub dir.
Exemple :
```php
// cwd = /var/www/html/
if (!$ftp->isDir('my/test/dir')) { // Directory do not exist
    $ftp->mkDirRecursive('my/test/dir');
}
// cwd /var/www/html
$ftp->put('my/test/dir'.$dest, $src);
if (!$ftp->isDir('my/test/dir')) {
    $ftp->mkDirRecursive('my/test/dir');
}
// cwd /var/www/html/my/test/dir
$ftp->put('my/test/dir'.$dest, $src);
```
This is a loop example with all steps "expanded"